### PR TITLE
add origin_consortium to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -95,16 +95,16 @@
 	},
 	{
 		"value": "brain networks"
-        },		
+        },
 	{
 		"value": "memory"
-        },		
+        },
 	{
 		"value": "visual rhythmic stimulation"
-        },		
+        },
 	{
 		"value": "theta oscillation"
-        }	
+        }
     ],
 	"primaryPublications" : [
 		{
@@ -175,6 +175,14 @@
             "values": [
                 {
                     "value": "Quebec"
+                }
+            ]
+        },
+{
+            "category": "origin_consortium",
+            "values": [
+                {
+                    "value": "EEGnet"
                 }
             ]
         },


### PR DESCRIPTION
This PR adds the value "EEGnet" to the `origin_consortium` field in DATS.json.